### PR TITLE
CamoFilter, EmojiFilter and File.write

### DIFF
--- a/lib/ghpreview/previewer.rb
+++ b/lib/ghpreview/previewer.rb
@@ -35,6 +35,7 @@ module GHPreview
       html = markdown_to_html
       html = wrap_content_with_full_document(html)
       File.open(HTML_FILEPATH, 'w') { |f| f << html }
+
       if RUBY_PLATFORM =~ /linux/
         command = 'xdg-open'
       else
@@ -47,14 +48,13 @@ module GHPreview
 
     def markdown_to_html
       markdown = File.read(@md_filepath)
+
       pipeline = HTML::Pipeline.new([
         HTML::Pipeline::MarkdownFilter,
         HTML::Pipeline::SanitizationFilter,
-#        HTML::Pipeline::CamoFilter,
         HTML::Pipeline::ImageMaxWidthFilter,
         HTML::Pipeline::HttpsFilter,
         HTML::Pipeline::MentionFilter,
-#        HTML::Pipeline::EmojiFilter,
         HTML::Pipeline::SyntaxHighlightFilter
       ], gfm: false)
       result = pipeline.call(markdown)[:output].to_s


### PR DESCRIPTION
1) **html-pipeline filters now need some kind of parameters.**
Comment out filters that need the new context parameters for the time being. So we can still install and use.

2) **File.write seems not to be there in 1.9.3?**
http://www.ruby-doc.org/core-1.9.3/File.html. Changed call to File::write for a working solution.
