### PR TITLE
Emoji Filter is back

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This is especially notable with fenced code blocks and syntax highlighting.
 
 `ghpreview` is an accurate preview because it uses Github's own [HTML 
 processing filters](https://github.com/jch/html-pipeline) to generate the HTML, 
-and Github's own stylesheets to style it.
+and Github's own stylesheets to style it :octocat:
 
 ## Contributing
 

--- a/lib/ghpreview/previewer.rb
+++ b/lib/ghpreview/previewer.rb
@@ -49,14 +49,20 @@ module GHPreview
     def markdown_to_html
       markdown = File.read(@md_filepath)
 
+      context = {
+        asset_root: "http://assets.github.com/images/icons/",
+        gfm: false
+      }
+
       pipeline = HTML::Pipeline.new([
         HTML::Pipeline::MarkdownFilter,
         HTML::Pipeline::SanitizationFilter,
         HTML::Pipeline::ImageMaxWidthFilter,
         HTML::Pipeline::HttpsFilter,
         HTML::Pipeline::MentionFilter,
+        HTML::Pipeline::EmojiFilter,
         HTML::Pipeline::SyntaxHighlightFilter
-      ], gfm: false)
+      ], context)
       result = pipeline.call(markdown)[:output].to_s
     end
 


### PR DESCRIPTION
I'm using Github's static CDN for emojis on this code. I contacted them via support to see if it's okay that we use this URL for the gem, hopefully they won't have any issues since it's a gem to use FOR Github. But you may want to wait until they answer back to merge this.
