### PR TITLE
Error on new install with linguist

### DIFF
--- a/ghpreview.gemspec
+++ b/ghpreview.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'listen'
   gem.add_dependency 'rb-fsevent'
-  gem.add_dependency 'html-pipeline', '0.0.4'
+  gem.add_dependency 'html-pipeline', '0.0.6'
   gem.add_dependency 'httpclient'
-  gem.add_dependency 'github-linguist', '2.3.4'
+  gem.add_dependency 'github-linguist', '2.1'
 end


### PR DESCRIPTION
Should fix #10.

Changes html-pipeline version to latest (0.0.6) and linguist version to 2.1
which is the one html-pipeline is using.

If you get an error similar to this:
`block in ffi_lib': Could not open library 'lib.so'`
It's probably related to the Python version. It was failing for me when using
Python 3, but started working when I switched to Python 2. (more info: [1](https://github.com/imathis/octopress/issues/704), [2](https://github.com/tmm1/pygments.rb/issues/10))
