### PR TITLE
Allow an alternate browser to be used with the -a switch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in github-preview.gemspec
+gem 'rake'
 gemspec

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ option:
 $ ghpreview -w README.md
 ```
 
+To use an alternate browser (Mac only), use the `-a` (or `--application`) option:
+
+```bash
+$ ghpreview -a Safari.app README.md
+```
+
 ## Why is this better than X?
 
 There are several tools available for previewing Markdown files, and many that 

--- a/bin/ghpreview
+++ b/bin/ghpreview
@@ -13,6 +13,10 @@ optparse = OptionParser.new do |opts|
   opts.on("-w", "--watch", "Watch for changes") do |w|
     options[:watch] = w
   end
+
+  opts.on("-a", "--application APP", "Alternate browser") do |a|
+    options[:application] = a
+  end
 end
 
 def valid_file? filename

--- a/lib/ghpreview/previewer.rb
+++ b/lib/ghpreview/previewer.rb
@@ -16,6 +16,7 @@ module GHPreview
       @http        = HTTPClient.new
       generate_template_with_fingerprinted_stylesheet_links
 
+      @application = options[:application]
       options[:watch] ? listen : open
     end
 
@@ -39,7 +40,7 @@ module GHPreview
       if RUBY_PLATFORM =~ /linux/
         command = 'xdg-open'
       else
-        command = 'open'
+        command = @application ? "open -a #{@application}" : 'open'
       end
       `#{command} #{HTML_FILEPATH}`
     end


### PR DESCRIPTION
I sometimes want to use a browser other than my default browser.  On a Mac, the "open" command can have a "-a" flag to specify the application you want to use.  This allows the user to do it on ghpreview.
