### PR TITLE
IDs for header elements to support anchor links

### DIFF
--- a/lib/ghpreview/converter.rb
+++ b/lib/ghpreview/converter.rb
@@ -10,6 +10,7 @@ module GHPreview
 
       pipeline = HTML::Pipeline.new([
         HTML::Pipeline::MarkdownFilter,
+        HTML::Pipeline::TableOfContentsFilter,
         HTML::Pipeline::SanitizationFilter,
         HTML::Pipeline::ImageMaxWidthFilter,
         HTML::Pipeline::HttpsFilter,

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -6,10 +6,14 @@ describe GHPreview::Converter do
   let(:converter) { GHPreview::Converter }
 
   it "converts markdown to HTML" do
-    expect(converter.to_html('# Foo')).to eql('<h1>Foo</h1>')
+    expect(converter.to_html('*Foo*')).to eql('<p><em>Foo</em></p>')
+  end
+
+  it "includes anchor links in headings" do
+    expect(converter.to_html('# Foo')).to eql("<h1>\n<a name=\"foo\" href=\"#foo\"></a>Foo</h1>")
   end
 
   it "passes through non-ASCII characters" do
-    expect(converter.to_html('# Baña')).to eql('<h1>Baña</h1>')
+    expect(converter.to_html('Baña')).to eql('<p>Baña</p>')
   end
 end


### PR DESCRIPTION
Very handy gem!
I found myself editing a long markdown file with several links to different sections. It would be nice if ghpreview could provide IDs in the heading tags to support anchor links, like GitHub does. This way I could click around and test any section links in the preview before pushing the README, to make sure I don't have any broken links.
