### PR TITLE
Fix crash for new installs

### DIFF
--- a/ghpreview.gemspec
+++ b/ghpreview.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rb-fsevent'
   gem.add_dependency 'html-pipeline', '0.0.6'
   gem.add_dependency 'httpclient'
-  gem.add_dependency 'github-linguist', '2.1'
 end


### PR DESCRIPTION
There seems to be a problem with github-linguist 2.1. Removing the
dependency will install github-linguist 2.6 which fixes the problem for
me.

The crash I was getting:

```
$ ghpreview README.md 
/Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/blankslate-3.1.2/lib/blankslate.rb:51: warning: undefining `object_id' may cause serious problems
/Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/mime-types-1.25/lib/mime/types.rb:105:in `priority_compare': undefined method `zero?' for nil:NilClass (NoMethodError)
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/mime-types-1.25/lib/mime/types.rb:656:in `block in []'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/mime-types-1.25/lib/mime/types.rb:656:in `sort'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/mime-types-1.25/lib/mime/types.rb:656:in `[]'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/mime-types-1.25/lib/mime/types.rb:848:in `[]'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/github-linguist-2.1.0/lib/linguist/mime.rb:26:in `block in <top (required)>'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/github-linguist-2.1.0/lib/linguist/mime.rb:12:in `each'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/github-linguist-2.1.0/lib/linguist/mime.rb:12:in `<top (required)>'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/github-linguist-2.1.0/lib/linguist/blob_helper.rb:3:in `<top (required)>'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/github-linguist-2.1.0/lib/linguist.rb:1:in `<top (required)>'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/html-pipeline-0.0.6/lib/html/pipeline/syntax_highlight_filter.rb:1:in `<top (required)>'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/ghpreview-0.0.9/lib/ghpreview/converter.rb:19:in `to_html'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/ghpreview-0.0.9/lib/ghpreview/previewer.rb:26:in `open'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/ghpreview-0.0.9/lib/ghpreview/previewer.rb:15:in `initialize'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/ghpreview-0.0.9/bin/ghpreview:35:in `new'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/ghpreview-0.0.9/bin/ghpreview:35:in `<top (required)>'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/bin/ghpreview:23:in `load'
    from /Users/enriquez/.rbenv/versions/2.0.0-p247/bin/ghpreview:23:in `<main>'
```

You might be able to reproduce this by uninstalling all versions of github-linguist except for version 2.1 from your system.
