### PR TITLE
Update gems to make it work again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 .bundle
+.byebug_history
 .config
 .yardoc
 Gemfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+## 0.2.0 - September 30th, 2019
+
+- First update after 6 years: Udpate gem versions to get the gem working again with modern rubies.
+- Currently tested in: 2.4, 2.5, 2.6 and ruby-head
+
+## 0.1.1 - December 23, 2013
+
+- Specify html-pipeline dependencies. Also now using Bundler to sandbox the required gems. This should make it fail if the dependencies are not specified in the gemspec.
+- Require rspec
+
+## 0.1.0 - December 22, 2013
+
+- Update Listener and use new API
+- Update versions of html-pipeline and github-linguist
+
+## 0.0.9 - August 9, 2013
+
+- Include anchor links in headings
+
+## 0.0.8 - June 22, 2013
+
+- Add convenience executables for testing
+- Extract Viewer, Wrapper, Converter, Watcher.
+- Allow an alternative browser to be used with the -a switch on GNU/Linux.
+
+## 0.0.7 - April 4, 2013
+
+- Alow an alternate browser to be used with the -a switch on Mac.
+
+## 0.0.6 - January 4, 2013
+
+- SIGINT trapping and error handling
+- Updates dependency versions
+
+## 0.0.5 - December 20, 2012
+
+- Lock version of github-linguist to known working version
+
+## 0.0.4 - December 18, 2012
+
+- Remove CamoFilter, add asset_root for EmojiFilter
+- Add note about icu.
+
+## 0.0.3 - November 30, 2012
+
+- Cache the stylesheets for a week
+- Avoids using the GitHub API and uses Github's html-pipeline.
+- Refactor obfuscated code.
+- Improvements on the README
+
+## 0.0.2 - November 26, 2012
+
+- Avoid SSL verifications errors when using open-uri
+- Adds Linux compatibility
+- Cache the fingerprinted stylesheets links for a day
+- Use ERB for HTML template
+- Add live updating preview as a command line option
+- Rename to ghpreview for better tab-completion
+
+## 0.0.1 - November 26, 2012
+
+- Initial release with executable.
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in github-preview.gemspec

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To use an alternate browser, use the `-a` (or `--application`) option:
 # On Mac:
 $ ghpreview -a Safari.app README.md
 
-#On GNU/Linux:
+# On GNU/Linux:
 $ ghpreview -a konqueror README.md
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,3 @@
-require "bundler/gem_tasks"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'

--- a/bin/ghpreview
+++ b/bin/ghpreview
@@ -1,32 +1,33 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-trap("INT") { exit }
+trap('INT') { exit }
 require 'optparse'
 require 'ghpreview'
 
 options = {}
 
 optparse = OptionParser.new do |opts|
-  opts.banner = "Usage: ghpreview [options] FILE"
-  opts.separator ""
+  opts.banner = 'Usage: ghpreview [options] FILE'
+  opts.separator ''
 
-  opts.on("-w", "--watch", "Watch for changes") do |w|
+  opts.on('-w', '--watch', 'Watch for changes') do |w|
     options[:watch] = w
   end
 
-  opts.on("-a", "--application APP", "Alternate browser") do |a|
+  opts.on('-a', '--application APP', 'Alternate browser') do |a|
     options[:application] = a
   end
 end
 
-def valid_file? filename
-  filename and File.exist?(filename) and File.file?(filename)
+def valid_file?(filename)
+  filename && File.exist?(filename) && File.file?(filename)
 end
 
 begin
   optparse.parse!
   unless valid_file? ARGV[0]
-    puts "Missing markdown file."
+    puts 'Missing markdown file.'
     puts optparse
     exit
   end

--- a/ghpreview.gemspec
+++ b/ghpreview.gemspec
@@ -8,25 +8,24 @@ Gem::Specification.new do |gem|
   gem.version       = GHPreview::VERSION
   gem.authors       = ['Adam McCrea']
   gem.email         = ['adam@adamlogic.com']
-  gem.description   = %q{Command line utility for previewing Markdown files with Github styling}
+  gem.description   = 'Command line utility for previewing Markdown files with Github styling'
   gem.summary       = gem.description
   gem.homepage      = 'http://github.com/edgecase/ghpreview'
 
-  gem.files         = `git ls-files`.split($/)
+  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'bundler', '~> 1.14.6'
-  gem.add_dependency 'listen', '~> 3.1.5'
-  gem.add_dependency 'rb-fsevent'
+  gem.add_dependency 'bundler', '~> 1.17.2'
+  gem.add_dependency 'gemoji', '~> 3.0'
+  gem.add_dependency 'github-linguist', '~> 7.6'
+  gem.add_dependency 'github-markdown', '~> 0.6'
   gem.add_dependency 'html-pipeline', '~> 2.5.0'
   gem.add_dependency 'html-pipeline-rouge_filter', '~> 1.0'
   gem.add_dependency 'httpclient'
-  gem.add_dependency 'github-linguist', '~> 5.0.8'
-  gem.add_dependency 'github-markdown', '~> 0.5'
+  gem.add_dependency 'listen', '~> 3.1.5'
+  gem.add_dependency 'rb-fsevent'
   gem.add_dependency 'rinku', '~> 2.0.2'
   gem.add_dependency 'sanitize', '~> 4.4.0'
-  gem.add_dependency 'gemoji', '~> 3.0'
 end
-

--- a/ghpreview.gemspec
+++ b/ghpreview.gemspec
@@ -1,5 +1,6 @@
-# -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'ghpreview/version'
 
@@ -27,8 +28,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'httpclient', '~> 2.8'
   gem.add_dependency 'listen', '~> 3.1.5'
   gem.add_dependency 'rb-fsevent'
-  gem.add_dependency 'rouge', '~> 3.1'
   gem.add_dependency 'rinku', '~> 1.7'
+  gem.add_dependency 'rouge', '~> 3.1'
   gem.add_dependency 'sanitize', '~> 4.4.0'
 
   gem.add_development_dependency 'byebug'

--- a/ghpreview.gemspec
+++ b/ghpreview.gemspec
@@ -18,14 +18,18 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'bundler', '~> 1.17.2'
-  gem.add_dependency 'gemoji', '~> 3.0'
+  gem.add_dependency 'commonmarker', '~> 0.16'
+  gem.add_dependency 'escape_utils', '~> 1.0'
+  gem.add_dependency 'gemoji', '~> 2.0'
   gem.add_dependency 'github-linguist', '~> 7.6'
   gem.add_dependency 'github-markdown', '~> 0.6'
-  gem.add_dependency 'html-pipeline', '~> 2.5.0'
-  gem.add_dependency 'html-pipeline-rouge_filter', '~> 1.0'
-  gem.add_dependency 'httpclient'
+  gem.add_dependency 'html-pipeline', '~> 2.12'
+  gem.add_dependency 'httpclient', '~> 2.8'
   gem.add_dependency 'listen', '~> 3.1.5'
   gem.add_dependency 'rb-fsevent'
-  gem.add_dependency 'rinku', '~> 2.0.2'
+  gem.add_dependency 'rouge', '~> 3.1'
+  gem.add_dependency 'rinku', '~> 1.7'
   gem.add_dependency 'sanitize', '~> 4.4.0'
+
+  gem.add_development_dependency 'byebug'
 end

--- a/ghpreview.gemspec
+++ b/ghpreview.gemspec
@@ -4,26 +4,29 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'ghpreview/version'
 
 Gem::Specification.new do |gem|
-  gem.name          = "ghpreview"
+  gem.name          = 'ghpreview'
   gem.version       = GHPreview::VERSION
-  gem.authors       = ["Adam McCrea"]
-  gem.email         = ["adam@adamlogic.com"]
+  gem.authors       = ['Adam McCrea']
+  gem.email         = ['adam@adamlogic.com']
   gem.description   = %q{Command line utility for previewing Markdown files with Github styling}
   gem.summary       = gem.description
-  gem.homepage      = "http://github.com/newcontext/ghpreview"
+  gem.homepage      = 'http://github.com/edgecase/ghpreview'
 
   gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  gem.require_paths = ['lib']
 
-  gem.add_dependency 'bundler', '~> 1.3'
-  gem.add_dependency 'listen', '~> 2.4.0'
+  gem.add_dependency 'bundler', '~> 1.14.6'
+  gem.add_dependency 'listen', '~> 3.1.5'
   gem.add_dependency 'rb-fsevent'
-  gem.add_dependency 'html-pipeline', '~> 1.1.0'
+  gem.add_dependency 'html-pipeline', '~> 2.5.0'
+  gem.add_dependency 'html-pipeline-rouge_filter', '~> 1.0'
   gem.add_dependency 'httpclient'
-  gem.add_dependency 'github-linguist', '~> 2.10.5'
+  gem.add_dependency 'github-linguist', '~> 5.0.8'
   gem.add_dependency 'github-markdown', '~> 0.5'
-  gem.add_dependency 'sanitize', '~> 2.0'
-  gem.add_dependency 'gemoji', '~> 1.0'
+  gem.add_dependency 'rinku', '~> 2.0.2'
+  gem.add_dependency 'sanitize', '~> 4.4.0'
+  gem.add_dependency 'gemoji', '~> 3.0'
 end
+

--- a/ghpreview.gemspec
+++ b/ghpreview.gemspec
@@ -7,8 +7,8 @@ require 'ghpreview/version'
 Gem::Specification.new do |gem|
   gem.name          = 'ghpreview'
   gem.version       = GHPreview::VERSION
-  gem.authors       = ['Adam McCrea']
-  gem.email         = ['adam@adamlogic.com']
+  gem.authors       = ['Adam McCrea', 'Fernando Briano']
+  gem.email         = ['fernando@picandocodigo.net', 'adam@adamlogic.com']
   gem.description   = 'Command line utility for previewing Markdown files with Github styling'
   gem.summary       = gem.description
   gem.homepage      = 'http://github.com/edgecase/ghpreview'
@@ -17,8 +17,15 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
+  gem.metadata      = {
+    "bug_tracker_uri"   => "https://github.com/edgecase/ghpreview/issues",
+    "changelog_uri"     => "https://github.com/edgecase/ghpreview/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://github.com/edgecase/ghpreview/blob/master/README.md#gamesdb",
+    "homepage_uri"      => "https://github.com/edgecase/ghpreview",
+    "source_code_uri"   => "https://github.com/edgecase/ghpreview",
+  }
 
-  gem.add_dependency 'bundler', '~> 1.17.2'
+  gem.add_dependency 'bundler'
   gem.add_dependency 'commonmarker', '~> 0.16'
   gem.add_dependency 'escape_utils', '~> 1.0'
   gem.add_dependency 'gemoji', '~> 2.0'

--- a/lib/ghpreview.rb
+++ b/lib/ghpreview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'bundler'
 require 'bundler/setup'

--- a/lib/ghpreview/converter.rb
+++ b/lib/ghpreview/converter.rb
@@ -1,26 +1,26 @@
 require 'html/pipeline'
-require 'html/pipeline/rouge_filter'
 
 module GHPreview
   class Converter
     def self.to_html(markdown)
       context = {
-        asset_root: 'http://assets.github.com/images/icons/',
-        base_url: 'http://assets.github.com/images/icons/',
+        asset_root: 'https://github.githubassets.com/images/icons/',
+        base_url: 'https://github.githubassets.com/images/icons/',
         gfm: false
       }
 
       pipeline = HTML::Pipeline.new([
         HTML::Pipeline::MarkdownFilter,
-        HTML::Pipeline::TableOfContentsFilter,
         HTML::Pipeline::SanitizationFilter,
         HTML::Pipeline::ImageMaxWidthFilter,
+        HTML::Pipeline::TableOfContentsFilter,
         HTML::Pipeline::HttpsFilter,
         HTML::Pipeline::AutolinkFilter,
         HTML::Pipeline::MentionFilter,
         HTML::Pipeline::EmojiFilter,
-        HTML::Pipeline::RougeFilter
+        HTML::Pipeline::SyntaxHighlightFilter
       ], context)
+
       pipeline.call(markdown)[:output].to_s
     end
   end

--- a/lib/ghpreview/converter.rb
+++ b/lib/ghpreview/converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'html/pipeline'
 
 module GHPreview
@@ -10,16 +12,16 @@ module GHPreview
       }
 
       pipeline = HTML::Pipeline.new([
-        HTML::Pipeline::MarkdownFilter,
-        HTML::Pipeline::SanitizationFilter,
-        HTML::Pipeline::ImageMaxWidthFilter,
-        HTML::Pipeline::TableOfContentsFilter,
-        HTML::Pipeline::HttpsFilter,
-        HTML::Pipeline::AutolinkFilter,
-        HTML::Pipeline::MentionFilter,
-        HTML::Pipeline::EmojiFilter,
-        HTML::Pipeline::SyntaxHighlightFilter
-      ], context)
+                                      HTML::Pipeline::MarkdownFilter,
+                                      HTML::Pipeline::SanitizationFilter,
+                                      HTML::Pipeline::ImageMaxWidthFilter,
+                                      HTML::Pipeline::TableOfContentsFilter,
+                                      HTML::Pipeline::HttpsFilter,
+                                      HTML::Pipeline::AutolinkFilter,
+                                      HTML::Pipeline::MentionFilter,
+                                      HTML::Pipeline::EmojiFilter,
+                                      HTML::Pipeline::SyntaxHighlightFilter
+                                    ], context)
 
       pipeline.call(markdown)[:output].to_s
     end

--- a/lib/ghpreview/converter.rb
+++ b/lib/ghpreview/converter.rb
@@ -1,10 +1,12 @@
 require 'html/pipeline'
+require 'html/pipeline/rouge_filter'
 
 module GHPreview
   class Converter
     def self.to_html(markdown)
       context = {
-        asset_root: "http://assets.github.com/images/icons/",
+        asset_root: 'http://assets.github.com/images/icons/',
+        base_url: 'http://assets.github.com/images/icons/',
         gfm: false
       }
 
@@ -14,11 +16,12 @@ module GHPreview
         HTML::Pipeline::SanitizationFilter,
         HTML::Pipeline::ImageMaxWidthFilter,
         HTML::Pipeline::HttpsFilter,
+        HTML::Pipeline::AutolinkFilter,
         HTML::Pipeline::MentionFilter,
         HTML::Pipeline::EmojiFilter,
-        HTML::Pipeline::SyntaxHighlightFilter
+        HTML::Pipeline::RougeFilter
       ], context)
-      result = pipeline.call(markdown)[:output].to_s
+      pipeline.call(markdown)[:output].to_s
     end
   end
 end

--- a/lib/ghpreview/previewer.rb
+++ b/lib/ghpreview/previewer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'converter'
 require_relative 'wrapper'
 require_relative 'viewer'
@@ -5,7 +7,6 @@ require_relative 'watcher'
 
 module GHPreview
   class Previewer
-
     def initialize(md_filepath, options = {})
       Wrapper.generate_template_with_fingerprinted_stylesheet_links
 
@@ -27,6 +28,5 @@ module GHPreview
       html = Wrapper.wrap_html(html)
       Viewer.view_html html, @application
     end
-
   end
 end

--- a/lib/ghpreview/version.rb
+++ b/lib/ghpreview/version.rb
@@ -1,3 +1,3 @@
 module GHPreview
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/lib/ghpreview/version.rb
+++ b/lib/ghpreview/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GHPreview
   VERSION = '0.1.0'
 end

--- a/lib/ghpreview/version.rb
+++ b/lib/ghpreview/version.rb
@@ -1,3 +1,3 @@
 module GHPreview
-  VERSION = "0.2.0"
+  VERSION = '0.1.0'
 end

--- a/lib/ghpreview/version.rb
+++ b/lib/ghpreview/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GHPreview
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/lib/ghpreview/viewer.rb
+++ b/lib/ghpreview/viewer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GHPreview
   class Viewer
     HTML_FILEPATH = '/tmp/ghpreview.html'
@@ -8,7 +10,7 @@ module GHPreview
       if RUBY_PLATFORM =~ /linux/
         command = if application
                     `#{application} #{HTML_FILEPATH} </dev/null &>/dev/null &`
-                    else
+                  else
                     `xdg-open #{HTML_FILEPATH}`
                   end
       else

--- a/lib/ghpreview/watcher.rb
+++ b/lib/ghpreview/watcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen'
 
 module GHPreview
@@ -8,7 +10,7 @@ module GHPreview
       filename = File.basename(filepath)
       dirname  = File.dirname(File.expand_path(filepath))
 
-      listener = Listen.to(dirname, filter: /#{filename}$/) do |modified|
+      listener = Listen.to(dirname, filter: /#{filename}$/) do |_modified|
         yield
       end
       listener.start

--- a/lib/ghpreview/wrapper.rb
+++ b/lib/ghpreview/wrapper.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'erb'
 require 'httpclient'
 
 module GHPreview
   class Wrapper
     GITHUB_URL               = 'https://github.com'
-    STYLED_TEMPLATE_FILEPATH = "/tmp/ghpreview-template.erb"
+    STYLED_TEMPLATE_FILEPATH = '/tmp/ghpreview-template.erb'
     TEMPLATE_CACHE_DURATION  = 60 * 60 * 24 * 7 # one week
     RAW_TEMPLATE_FILEPATH    = "#{File.dirname(__FILE__)}/template.erb"
 
@@ -32,9 +34,9 @@ module GHPreview
     private
 
     def self.stale_template?(filepath)
-      return true unless File.exists?(filepath)
+      return true unless File.exist?(filepath)
+
       File.mtime(filepath) < (Time.now - TEMPLATE_CACHE_DURATION)
     end
-
   end
 end

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -1,11 +1,11 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../lib/ghpreview/converter'
 
 describe GHPreview::Converter do
   let(:converter) { GHPreview::Converter }
 
-  it "converts markdown to HTML" do
+  it 'converts markdown to HTML' do
     expect(converter.to_html('*Foo*')).to eql('<p><em>Foo</em></p>')
   end
 
@@ -13,7 +13,7 @@ describe GHPreview::Converter do
     expect(converter.to_html('# Foo')).to eql("<h1>\n<a id=\"foo\" class=\"anchor\" href=\"#foo\" aria-hidden=\"true\"><span aria-hidden=\"true\" class=\"octicon octicon-link\"></span></a>Foo</h1>")
   end
 
-  it "passes through non-ASCII characters" do
+  it 'passes through non-ASCII characters' do
     expect(converter.to_html('Baña')).to eql('<p>Baña</p>')
   end
 end

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -10,7 +10,7 @@ describe GHPreview::Converter do
   end
 
   it 'includes anchor links in headings' do
-    expect(converter.to_html('# Foo')).to eql("<h1>\n<a href=\"#foo\"></a>Foo</h1>")
+    expect(converter.to_html('# Foo')).to eql("<h1>\n<a id=\"foo\" class=\"anchor\" href=\"#foo\" aria-hidden=\"true\"><span aria-hidden=\"true\" class=\"octicon octicon-link\"></span></a>Foo</h1>")
   end
 
   it "passes through non-ASCII characters" do

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -9,8 +9,8 @@ describe GHPreview::Converter do
     expect(converter.to_html('*Foo*')).to eql('<p><em>Foo</em></p>')
   end
 
-  it "includes anchor links in headings" do
-    expect(converter.to_html('# Foo')).to eql("<h1>\n<a name=\"foo\" href=\"#foo\"></a>Foo</h1>")
+  it 'includes anchor links in headings' do
+    expect(converter.to_html('# Foo')).to eql("<h1>\n<a href=\"#foo\"></a>Foo</h1>")
   end
 
   it "passes through non-ASCII characters" do

--- a/spec/preview_readme
+++ b/spec/preview_readme
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require './lib/ghpreview'
 

--- a/spec/watch_readme
+++ b/spec/watch_readme
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require './lib/ghpreview'
 

--- a/spec/wrapper_spec.rb
+++ b/spec/wrapper_spec.rb
@@ -1,20 +1,20 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 
 require_relative '../lib/ghpreview/wrapper'
 
 describe GHPreview::Wrapper do
   let(:wrapper) { GHPreview::Wrapper }
 
-  it "wraps an HTML fragment in a full document" do
+  it 'wraps an HTML fragment in a full document' do
     fragment = '<h1>foo</h1>'
     expect(wrapper.wrap_html(fragment)).to include('<html>')
   end
 
-  it "passes through non-ASCII chars" do
+  it 'passes through non-ASCII chars' do
     expect(wrapper.wrap_html('<h1>Baña</h1>')).to include('Baña')
   end
 
-  it "specifies the charset" do
+  it 'specifies the charset' do
     expect(wrapper.wrap_html('# foo')).to include("charset='utf-8'")
   end
 end


### PR DESCRIPTION
Not sure if the intention is to keep maintaining this gem, but I wanted to install it recently and found it didn't work with Ruby 2.4. I managed to fix it for me by updating the gems and replacing html-pipeline's SyntaxHighlightFilter with RougeFilter.